### PR TITLE
Removed global state from usb_cam by encapsulating it inside an object

### DIFF
--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -125,22 +125,22 @@ class UsbCam {
   void grab_image();
 
 
-  char *camera_dev;
-  unsigned int pixelformat;
-  bool monochrome;
-  io_method io;
-  int fd;
-  buffer * buffers;
-  unsigned int n_buffers;
-  AVFrame *avframe_camera;
-  AVFrame *avframe_rgb;
-  AVCodec *avcodec;
-  AVDictionary *avoptions;
-  AVCodecContext *avcodec_context;
-  int avframe_camera_size;
-  int avframe_rgb_size;
-  struct SwsContext *video_sws;
-  camera_image_t *image;
+  char *camera_dev_;
+  unsigned int pixelformat_;
+  bool monochrome_;
+  io_method io_;
+  int fd_;
+  buffer * buffers_;
+  unsigned int n_buffers_;
+  AVFrame *avframe_camera_;
+  AVFrame *avframe_rgb_;
+  AVCodec *avcodec_;
+  AVDictionary *avoptions_;
+  AVCodecContext *avcodec_context_;
+  int avframe_camera_size_;
+  int avframe_rgb_size_;
+  struct SwsContext *video_sws_;
+  camera_image_t *image_;
 
 };
 

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -90,7 +90,8 @@ class UsbCam {
   void camera_set_auto_focus(int value);
 
   // Set video device parameters
-  void set_v4l_parameters(std::string param);
+  void set_v4l_parameter(const std::string& param, int value);
+  void set_v4l_parameter(const std::string& param, const std::string& value);
 
  private:
   int init_mjpeg_decoder(int image_width, int image_height);

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -90,7 +90,7 @@ class UsbCam {
   void camera_set_auto_focus(int value);
 
   // Set video device parameters
-  static void set_v4l_parameters(std::string dev, std::string param);
+  void set_v4l_parameters(std::string param);
 
  private:
   int init_mjpeg_decoder(int image_width, int image_height);

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -61,15 +61,16 @@ class UsbCam {
  public:
   typedef enum
   {
-    IO_METHOD_READ, IO_METHOD_MMAP, IO_METHOD_USERPTR,
+    IO_METHOD_READ, IO_METHOD_MMAP, IO_METHOD_USERPTR, IO_METHOD_UNKNOWN,
   } io_method;
 
   typedef enum
   {
-    PIXEL_FORMAT_YUYV, PIXEL_FORMAT_UYVY, PIXEL_FORMAT_MJPEG, PIXEL_FORMAT_YUVMONO10, PIXEL_FORMAT_RGB24
+    PIXEL_FORMAT_YUYV, PIXEL_FORMAT_UYVY, PIXEL_FORMAT_MJPEG, PIXEL_FORMAT_YUVMONO10, PIXEL_FORMAT_RGB24, PIXEL_FORMAT_UNKNOWN
   } pixel_format;
 
   UsbCam();
+  ~UsbCam();
 
   // start camera
   void camera_start(const char* dev, io_method io, pixel_format pf,
@@ -85,6 +86,9 @@ class UsbCam {
   // Set video device parameters
   void set_v4l_parameter(const std::string& param, int value);
   void set_v4l_parameter(const std::string& param, const std::string& value);
+
+  static io_method io_method_from_string(const std::string& str);
+  static pixel_format pixel_format_from_string(const std::string& str);
 
  private:
   typedef struct

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -73,15 +73,16 @@ class UsbCam {
   ~UsbCam();
 
   // start camera
-  void camera_start(const char* dev, io_method io, pixel_format pf,
+  void start(const char* dev, io_method io, pixel_format pf,
 		    int image_width, int image_height, int framerate);
   // shutdown camera
-  void camera_shutdown(void);
+  void shutdown(void);
+
   // grabs a new image from the camera
-  void camera_grab_image(sensor_msgs::Image* image);
+  void grab_image(sensor_msgs::Image* image);
 
   // enables/disable auto focus
-  void camera_set_auto_focus(int value);
+  void set_auto_focus(int value);
 
   // Set video device parameters
   void set_v4l_parameter(const std::string& param, int value);
@@ -121,7 +122,7 @@ class UsbCam {
   void init_device(int image_width, int image_height, int framerate);
   void close_device(void);
   void open_device(void);
-  void camera_grab_image();
+  void grab_image();
 
 
   char *camera_dev;

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -75,7 +75,7 @@ class UsbCam {
   ~UsbCam();
 
   // start camera
-  void start(const char* dev, io_method io, pixel_format pf,
+  void start(const std::string& dev, io_method io, pixel_format pf,
 		    int image_width, int image_height, int framerate);
   // shutdown camera
   void shutdown(void);
@@ -127,7 +127,7 @@ class UsbCam {
   void grab_image();
 
 
-  char *camera_dev_;
+  std::string camera_dev_;
   unsigned int pixelformat_;
   bool monochrome_;
   io_method io_;

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -57,6 +57,8 @@ extern "C"
 
 #include <sensor_msgs/Image.h>
 
+namespace usb_cam {
+
 class UsbCam {
  public:
   typedef enum
@@ -143,6 +145,8 @@ class UsbCam {
   camera_image_t *image_;
 
 };
+
+}
 
 #endif
 

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -89,6 +89,9 @@ class UsbCam {
   // enables/disable auto focus
   void camera_set_auto_focus(int value);
 
+  // Set video device parameters
+  static void set_v4l_parameters(std::string dev, std::string param);
+
  private:
   int init_mjpeg_decoder(int image_width, int image_height);
   void mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels);

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -150,72 +150,58 @@ public:
         image_height_, framerate_);
 
     // set camera parameters
-    std::stringstream paramstream;
     if (brightness_ >= 0)
     {
-      paramstream << "brightness=" << brightness_;
-      cam.set_v4l_parameters(paramstream.str());
-      paramstream.str("");
+      cam.set_v4l_parameter("brightness", brightness_);
     }
 
     if (contrast_ >= 0)
     {
-      paramstream << "contrast=" << contrast_;
-      cam.set_v4l_parameters(paramstream.str());
-      paramstream.str("");
+      cam.set_v4l_parameter("contrast", contrast_);
     }
 
     if (saturation_ >= 0)
     {
-      paramstream << "saturation=" << saturation_;
-      cam.set_v4l_parameters(paramstream.str());
-      paramstream.str("");
+      cam.set_v4l_parameter("saturation", saturation_);
     }
 
     if (sharpness_ >= 0)
     {
-      paramstream << "sharpness=" << sharpness_;
-      cam.set_v4l_parameters(paramstream.str());
+      cam.set_v4l_parameter("sharpness", sharpness_);
     }
 
     // check auto white balance
     if (auto_white_balance_)
     {
-      cam.set_v4l_parameters("white_balance_temperature_auto=1");
+      cam.set_v4l_parameter("white_balance_temperature_auto", 1);
     }
     else
     {
-      cam.set_v4l_parameters("white_balance_temperature_auto=0");
-      std::stringstream ss;
-      ss << "white_balance_temperature=" << white_balance_;
-      cam.set_v4l_parameters(ss.str());
+      cam.set_v4l_parameter("white_balance_temperature_auto", 0);
+      cam.set_v4l_parameter("white_balance_temperature", white_balance_);
     }
 
     // check auto exposure
     if (!autoexposure_)
     {
       // turn down exposure control (from max of 3)
-      cam.set_v4l_parameters("exposure_auto=1");
+      cam.set_v4l_parameter("exposure_auto", 1);
       // change the exposure level
-      std::stringstream ss;
-      ss << "exposure_absolute=" << exposure_;
-      cam.set_v4l_parameters(ss.str());
+      cam.set_v4l_parameter("exposure_absolute", exposure_);
     }
 
     // check auto focus
     if (autofocus_)
     {
       cam.camera_set_auto_focus(1);
-      cam.set_v4l_parameters("focus_auto=1");
+      cam.set_v4l_parameter("focus_auto", 1);
     }
     else
     {
-      cam.set_v4l_parameters("focus_auto=0");
+      cam.set_v4l_parameter("focus_auto", 0);
       if (focus_ >= 0)
       {
-        std::stringstream ss;
-        ss << "focus_absolute=" << focus_;
-        cam.set_v4l_parameters(ss.str());
+        cam.set_v4l_parameter("focus_absolute", focus_);
       }
     }
   }

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -40,6 +40,8 @@
 #include <camera_info_manager/camera_info_manager.h>
 #include <sstream>
 
+namespace usb_cam {
+
 class UsbCamNode
 {
 public:
@@ -223,10 +225,12 @@ public:
   }
 };
 
+}
+
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "usb_cam");
-  UsbCamNode a;
+  usb_cam::UsbCamNode a;
   a.spin();
   return EXIT_SUCCESS;
 }

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -110,14 +110,8 @@ public:
         image_width_, image_height_, io_method_name_.c_str(), pixel_format_name_.c_str(), framerate_);
 
     // set the IO method
-    UsbCam::io_method io_method;
-    if (io_method_name_ == "mmap")
-      io_method = UsbCam::IO_METHOD_MMAP;
-    else if (io_method_name_ == "read")
-      io_method = UsbCam::IO_METHOD_READ;
-    else if (io_method_name_ == "userptr")
-      io_method = UsbCam::IO_METHOD_USERPTR;
-    else
+    UsbCam::io_method io_method = UsbCam::io_method_from_string(io_method_name_);
+    if(io_method == UsbCam::IO_METHOD_UNKNOWN)
     {
       ROS_FATAL("Unknown IO method '%s'", io_method_name_.c_str());
       node_.shutdown();
@@ -125,18 +119,8 @@ public:
     }
 
     // set the pixel format
-    UsbCam::pixel_format pixel_format;
-    if (pixel_format_name_ == "yuyv")
-      pixel_format = UsbCam::PIXEL_FORMAT_YUYV;
-    else if (pixel_format_name_ == "uyvy")
-      pixel_format = UsbCam::PIXEL_FORMAT_UYVY;
-    else if (pixel_format_name_ == "mjpeg")
-      pixel_format = UsbCam::PIXEL_FORMAT_MJPEG;
-    else if (pixel_format_name_ == "yuvmono10")
-      pixel_format = UsbCam::PIXEL_FORMAT_YUVMONO10;
-    else if (pixel_format_name_ == "rgb24")
-      pixel_format = UsbCam::PIXEL_FORMAT_RGB24;
-    else
+    UsbCam::pixel_format pixel_format = UsbCam::pixel_format_from_string(pixel_format_name_);
+    if (pixel_format == UsbCam::PIXEL_FORMAT_UNKNOWN)
     {
       ROS_FATAL("Unknown pixel format '%s'", pixel_format_name_.c_str());
       node_.shutdown();

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -49,7 +49,7 @@ public:
 
   // shared image message
   sensor_msgs::Image img_;
-  usb_cam_camera_image_t *camera_image_;
+  UsbCam::camera_image_t *camera_image_;
   image_transport::CameraPublisher image_pub_;
 
   // parameters
@@ -58,6 +58,8 @@ public:
       white_balance_;
   bool autofocus_, autoexposure_, auto_white_balance_;
   boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_;
+
+  UsbCam cam;
 
   UsbCamNode() :
       node_("~")
@@ -110,13 +112,13 @@ public:
         image_width_, image_height_, io_method_name_.c_str(), pixel_format_name_.c_str(), framerate_);
 
     // set the IO method
-    usb_cam_io_method io_method;
+    UsbCam::io_method io_method;
     if (io_method_name_ == "mmap")
-      io_method = IO_METHOD_MMAP;
+      io_method = UsbCam::IO_METHOD_MMAP;
     else if (io_method_name_ == "read")
-      io_method = IO_METHOD_READ;
+      io_method = UsbCam::IO_METHOD_READ;
     else if (io_method_name_ == "userptr")
-      io_method = IO_METHOD_USERPTR;
+      io_method = UsbCam::IO_METHOD_USERPTR;
     else
     {
       ROS_FATAL("Unknown IO method '%s'", io_method_name_.c_str());
@@ -125,17 +127,17 @@ public:
     }
 
     // set the pixel format
-    usb_cam_pixel_format pixel_format;
+    UsbCam::pixel_format pixel_format;
     if (pixel_format_name_ == "yuyv")
-      pixel_format = PIXEL_FORMAT_YUYV;
+      pixel_format = UsbCam::PIXEL_FORMAT_YUYV;
     else if (pixel_format_name_ == "uyvy")
-      pixel_format = PIXEL_FORMAT_UYVY;
+      pixel_format = UsbCam::PIXEL_FORMAT_UYVY;
     else if (pixel_format_name_ == "mjpeg")
-      pixel_format = PIXEL_FORMAT_MJPEG;
+      pixel_format = UsbCam::PIXEL_FORMAT_MJPEG;
     else if (pixel_format_name_ == "yuvmono10")
-      pixel_format = PIXEL_FORMAT_YUVMONO10;
+      pixel_format = UsbCam::PIXEL_FORMAT_YUVMONO10;
     else if (pixel_format_name_ == "rgb24")
-      pixel_format = PIXEL_FORMAT_RGB24;
+      pixel_format = UsbCam::PIXEL_FORMAT_RGB24;
     else
     {
       ROS_FATAL("Unknown pixel format '%s'", pixel_format_name_.c_str());
@@ -144,7 +146,7 @@ public:
     }
 
     // start the camera
-    camera_image_ = usb_cam_camera_start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
+    camera_image_ = cam.camera_start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
         image_height_, framerate_);
 
     // set camera parameters
@@ -203,7 +205,7 @@ public:
     // check auto focus
     if (autofocus_)
     {
-      usb_cam_camera_set_auto_focus(1);
+      cam.camera_set_auto_focus(1);
       this->set_v4l_parameters(video_device_name_, "focus_auto=1");
     }
     else
@@ -220,13 +222,13 @@ public:
 
   virtual ~UsbCamNode()
   {
-    usb_cam_camera_shutdown();
+    cam.camera_shutdown();
   }
 
   bool take_and_send_image()
   {
     // grab the image
-    usb_cam_camera_grab_image(camera_image_);
+    cam.camera_grab_image(camera_image_);
     // fill the info
     fillImage(img_, "rgb8", camera_image_->height, camera_image_->width, 3 * camera_image_->width,
         camera_image_->image);

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -154,68 +154,68 @@ public:
     if (brightness_ >= 0)
     {
       paramstream << "brightness=" << brightness_;
-      this->set_v4l_parameters(video_device_name_, paramstream.str());
+      UsbCam::set_v4l_parameters(video_device_name_, paramstream.str());
       paramstream.str("");
     }
 
     if (contrast_ >= 0)
     {
       paramstream << "contrast=" << contrast_;
-      this->set_v4l_parameters(video_device_name_, paramstream.str());
+      UsbCam::set_v4l_parameters(video_device_name_, paramstream.str());
       paramstream.str("");
     }
 
     if (saturation_ >= 0)
     {
       paramstream << "saturation=" << saturation_;
-      this->set_v4l_parameters(video_device_name_, paramstream.str());
+      UsbCam::set_v4l_parameters(video_device_name_, paramstream.str());
       paramstream.str("");
     }
 
     if (sharpness_ >= 0)
     {
       paramstream << "sharpness=" << sharpness_;
-      this->set_v4l_parameters(video_device_name_, paramstream.str());
+      UsbCam::set_v4l_parameters(video_device_name_, paramstream.str());
     }
 
     // check auto white balance
     if (auto_white_balance_)
     {
-      this->set_v4l_parameters(video_device_name_, "white_balance_temperature_auto=1");
+      UsbCam::set_v4l_parameters(video_device_name_, "white_balance_temperature_auto=1");
     }
     else
     {
-      this->set_v4l_parameters(video_device_name_, "white_balance_temperature_auto=0");
+      UsbCam::set_v4l_parameters(video_device_name_, "white_balance_temperature_auto=0");
       std::stringstream ss;
       ss << "white_balance_temperature=" << white_balance_;
-      this->set_v4l_parameters(video_device_name_, ss.str());
+      UsbCam::set_v4l_parameters(video_device_name_, ss.str());
     }
 
     // check auto exposure
     if (!autoexposure_)
     {
       // turn down exposure control (from max of 3)
-      this->set_v4l_parameters(video_device_name_, "exposure_auto=1");
+      UsbCam::set_v4l_parameters(video_device_name_, "exposure_auto=1");
       // change the exposure level
       std::stringstream ss;
       ss << "exposure_absolute=" << exposure_;
-      this->set_v4l_parameters(video_device_name_, ss.str());
+      UsbCam::set_v4l_parameters(video_device_name_, ss.str());
     }
 
     // check auto focus
     if (autofocus_)
     {
       cam.camera_set_auto_focus(1);
-      this->set_v4l_parameters(video_device_name_, "focus_auto=1");
+      UsbCam::set_v4l_parameters(video_device_name_, "focus_auto=1");
     }
     else
     {
-      this->set_v4l_parameters(video_device_name_, "focus_auto=0");
+      UsbCam::set_v4l_parameters(video_device_name_, "focus_auto=0");
       if (focus_ >= 0)
       {
         std::stringstream ss;
         ss << "focus_absolute=" << focus_;
-        this->set_v4l_parameters(video_device_name_, ss.str());
+        UsbCam::set_v4l_parameters(video_device_name_, ss.str());
       }
     }
   }
@@ -261,37 +261,6 @@ public:
 
 private:
 
-  /**
-  * Set video device parameters via calls to v4l-utils.
-  *
-  * @param dev The device (e.g., "/dev/video0")
-  * @param param The full parameter to set (e.g., "focus_auto=1")
-  */
-  void set_v4l_parameters(std::string dev, std::string param)
-  {
-    // build the command
-    std::stringstream ss;
-    ss << "v4l2-ctl --device=" << dev << " -c " << param << " 2>&1";
-    std::string cmd = ss.str();
-
-    // capture the output
-    std::string output;
-    int buffer_size = 256;
-    char buffer[buffer_size];
-    FILE *stream = popen(cmd.c_str(), "r");
-    if (stream)
-    {
-      while (!feof(stream))
-        if (fgets(buffer, buffer_size, stream) != NULL)
-          output.append(buffer);
-      pclose(stream);
-      // any output should be an error
-      if (output.length() > 0)
-        ROS_WARN("%s", output.c_str());
-    }
-    else
-      ROS_WARN("usb_cam_node could not run '%s'", cmd.c_str());
-  }
 };
 
 int main(int argc, char **argv)

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -57,7 +57,7 @@ public:
   bool autofocus_, autoexposure_, auto_white_balance_;
   boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_;
 
-  UsbCam cam;
+  UsbCam cam_;
 
   UsbCamNode() :
       node_("~")
@@ -128,75 +128,75 @@ public:
     }
 
     // start the camera
-    cam.start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
+    cam_.start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
 		     image_height_, framerate_);
 
     // set camera parameters
     if (brightness_ >= 0)
     {
-      cam.set_v4l_parameter("brightness", brightness_);
+      cam_.set_v4l_parameter("brightness", brightness_);
     }
 
     if (contrast_ >= 0)
     {
-      cam.set_v4l_parameter("contrast", contrast_);
+      cam_.set_v4l_parameter("contrast", contrast_);
     }
 
     if (saturation_ >= 0)
     {
-      cam.set_v4l_parameter("saturation", saturation_);
+      cam_.set_v4l_parameter("saturation", saturation_);
     }
 
     if (sharpness_ >= 0)
     {
-      cam.set_v4l_parameter("sharpness", sharpness_);
+      cam_.set_v4l_parameter("sharpness", sharpness_);
     }
 
     // check auto white balance
     if (auto_white_balance_)
     {
-      cam.set_v4l_parameter("white_balance_temperature_auto", 1);
+      cam_.set_v4l_parameter("white_balance_temperature_auto", 1);
     }
     else
     {
-      cam.set_v4l_parameter("white_balance_temperature_auto", 0);
-      cam.set_v4l_parameter("white_balance_temperature", white_balance_);
+      cam_.set_v4l_parameter("white_balance_temperature_auto", 0);
+      cam_.set_v4l_parameter("white_balance_temperature", white_balance_);
     }
 
     // check auto exposure
     if (!autoexposure_)
     {
       // turn down exposure control (from max of 3)
-      cam.set_v4l_parameter("exposure_auto", 1);
+      cam_.set_v4l_parameter("exposure_auto", 1);
       // change the exposure level
-      cam.set_v4l_parameter("exposure_absolute", exposure_);
+      cam_.set_v4l_parameter("exposure_absolute", exposure_);
     }
 
     // check auto focus
     if (autofocus_)
     {
-      cam.set_auto_focus(1);
-      cam.set_v4l_parameter("focus_auto", 1);
+      cam_.set_auto_focus(1);
+      cam_.set_v4l_parameter("focus_auto", 1);
     }
     else
     {
-      cam.set_v4l_parameter("focus_auto", 0);
+      cam_.set_v4l_parameter("focus_auto", 0);
       if (focus_ >= 0)
       {
-        cam.set_v4l_parameter("focus_absolute", focus_);
+        cam_.set_v4l_parameter("focus_absolute", focus_);
       }
     }
   }
 
   virtual ~UsbCamNode()
   {
-    cam.shutdown();
+    cam_.shutdown();
   }
 
   bool take_and_send_image()
   {
     // grab the image
-    cam.grab_image(&img_);
+    cam_.grab_image(&img_);
 
     // grab the camera info
     sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -128,7 +128,7 @@ public:
     }
 
     // start the camera
-    cam.camera_start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
+    cam.start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
 		     image_height_, framerate_);
 
     // set camera parameters
@@ -175,7 +175,7 @@ public:
     // check auto focus
     if (autofocus_)
     {
-      cam.camera_set_auto_focus(1);
+      cam.set_auto_focus(1);
       cam.set_v4l_parameter("focus_auto", 1);
     }
     else
@@ -190,13 +190,13 @@ public:
 
   virtual ~UsbCamNode()
   {
-    cam.camera_shutdown();
+    cam.shutdown();
   }
 
   bool take_and_send_image()
   {
     // grab the image
-    cam.camera_grab_image(&img_);
+    cam.grab_image(&img_);
 
     // grab the camera info
     sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -35,7 +35,6 @@
 *********************************************************************/
 
 #include <ros/ros.h>
-#include <sensor_msgs/fill_image.h>
 #include <usb_cam/usb_cam.h>
 #include <image_transport/image_transport.h>
 #include <camera_info_manager/camera_info_manager.h>
@@ -49,7 +48,6 @@ public:
 
   // shared image message
   sensor_msgs::Image img_;
-  UsbCam::camera_image_t *camera_image_;
   image_transport::CameraPublisher image_pub_;
 
   // parameters
@@ -146,8 +144,8 @@ public:
     }
 
     // start the camera
-    camera_image_ = cam.camera_start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
-        image_height_, framerate_);
+    cam.camera_start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
+		     image_height_, framerate_);
 
     // set camera parameters
     if (brightness_ >= 0)
@@ -214,12 +212,7 @@ public:
   bool take_and_send_image()
   {
     // grab the image
-    cam.camera_grab_image(camera_image_);
-    // fill the info
-    fillImage(img_, "rgb8", camera_image_->height, camera_image_->width, 3 * camera_image_->width,
-        camera_image_->image);
-    // stamp the image
-    img_.header.stamp = ros::Time::now();
+    cam.camera_grab_image(&img_);
 
     // grab the camera info
     sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));
@@ -244,9 +237,6 @@ public:
     }
     return true;
   }
-
-private:
-
 };
 
 int main(int argc, char **argv)

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -154,68 +154,68 @@ public:
     if (brightness_ >= 0)
     {
       paramstream << "brightness=" << brightness_;
-      UsbCam::set_v4l_parameters(video_device_name_, paramstream.str());
+      cam.set_v4l_parameters(paramstream.str());
       paramstream.str("");
     }
 
     if (contrast_ >= 0)
     {
       paramstream << "contrast=" << contrast_;
-      UsbCam::set_v4l_parameters(video_device_name_, paramstream.str());
+      cam.set_v4l_parameters(paramstream.str());
       paramstream.str("");
     }
 
     if (saturation_ >= 0)
     {
       paramstream << "saturation=" << saturation_;
-      UsbCam::set_v4l_parameters(video_device_name_, paramstream.str());
+      cam.set_v4l_parameters(paramstream.str());
       paramstream.str("");
     }
 
     if (sharpness_ >= 0)
     {
       paramstream << "sharpness=" << sharpness_;
-      UsbCam::set_v4l_parameters(video_device_name_, paramstream.str());
+      cam.set_v4l_parameters(paramstream.str());
     }
 
     // check auto white balance
     if (auto_white_balance_)
     {
-      UsbCam::set_v4l_parameters(video_device_name_, "white_balance_temperature_auto=1");
+      cam.set_v4l_parameters("white_balance_temperature_auto=1");
     }
     else
     {
-      UsbCam::set_v4l_parameters(video_device_name_, "white_balance_temperature_auto=0");
+      cam.set_v4l_parameters("white_balance_temperature_auto=0");
       std::stringstream ss;
       ss << "white_balance_temperature=" << white_balance_;
-      UsbCam::set_v4l_parameters(video_device_name_, ss.str());
+      cam.set_v4l_parameters(ss.str());
     }
 
     // check auto exposure
     if (!autoexposure_)
     {
       // turn down exposure control (from max of 3)
-      UsbCam::set_v4l_parameters(video_device_name_, "exposure_auto=1");
+      cam.set_v4l_parameters("exposure_auto=1");
       // change the exposure level
       std::stringstream ss;
       ss << "exposure_absolute=" << exposure_;
-      UsbCam::set_v4l_parameters(video_device_name_, ss.str());
+      cam.set_v4l_parameters(ss.str());
     }
 
     // check auto focus
     if (autofocus_)
     {
       cam.camera_set_auto_focus(1);
-      UsbCam::set_v4l_parameters(video_device_name_, "focus_auto=1");
+      cam.set_v4l_parameters("focus_auto=1");
     }
     else
     {
-      UsbCam::set_v4l_parameters(video_device_name_, "focus_auto=0");
+      cam.set_v4l_parameters("focus_auto=0");
       if (focus_ >= 0)
       {
         std::stringstream ss;
         ss << "focus_absolute=" << focus_;
-        UsbCam::set_v4l_parameters(video_device_name_, ss.str());
+        cam.set_v4l_parameters(ss.str());
       }
     }
   }

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -49,6 +49,7 @@
 #include <sys/ioctl.h>
 
 #include <ros/ros.h>
+#include <boost/lexical_cast.hpp>
 
 #include <usb_cam/usb_cam.h>
 
@@ -1129,15 +1130,26 @@ void UsbCam::camera_set_auto_focus(int value)
 }
 
 /**
-* Set video device parameters via calls to v4l-utils.
+* Set video device parameter via call to v4l-utils.
 *
-* @param param The full parameter to set (e.g., "focus_auto=1")
+* @param param The name of the parameter to set
+* @param param The value to assign
 */
-void UsbCam::set_v4l_parameters(std::string param)
+void UsbCam::set_v4l_parameter(const std::string& param, int value)
+{
+  set_v4l_parameter(param, boost::lexical_cast<std::string>(value));
+}
+/**
+* Set video device parameter via call to v4l-utils.
+*
+* @param param The name of the parameter to set
+* @param param The value to assign
+*/
+void UsbCam::set_v4l_parameter(const std::string& param, const std::string& value)
 {
   // build the command
   std::stringstream ss;
-  ss << "v4l2-ctl --device=" << camera_dev << " -c " << param << " 2>&1";
+  ss << "v4l2-ctl --device=" << camera_dev << " -c " << param << "=" << value << " 2>&1";
   std::string cmd = ss.str();
 
   // capture the output

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -60,7 +60,7 @@ namespace usb_cam {
 
 static void errno_exit(const char * s)
 {
-  ROS_ERROR("%s error %d, %s\n", s, errno, strerror(errno));
+  ROS_ERROR("%s error %d, %s", s, errno, strerror(errno));
   exit(EXIT_FAILURE);
 }
 
@@ -373,7 +373,7 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
   avcodec_ = avcodec_find_decoder(AV_CODEC_ID_MJPEG);
   if (!avcodec_)
   {
-    ROS_ERROR("Could not find MJPEG decoder\n");
+    ROS_ERROR("Could not find MJPEG decoder");
     return 0;
   }
 
@@ -398,7 +398,7 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
   /* open it */
   if (avcodec_open2(avcodec_context_, avcodec_, &avoptions_) < 0)
   {
-    ROS_ERROR("Could not open MJPEG Decoder\n");
+    ROS_ERROR("Could not open MJPEG Decoder");
     return 0;
   }
   return 1;
@@ -421,7 +421,7 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
 
   if (decoded_len < 0)
   {
-    ROS_ERROR("Error while decoding frame.\n");
+    ROS_ERROR("Error while decoding frame.");
     return;
   }
 #else
@@ -430,7 +430,7 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
 
   if (!got_picture)
   {
-    ROS_ERROR("Webcam: expected picture but didn't get it...\n");
+    ROS_ERROR("Webcam: expected picture but didn't get it...");
     return;
   }
 
@@ -439,7 +439,7 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
   int pic_size = avpicture_get_size(avcodec_context_->pix_fmt, xsize, ysize);
   if (pic_size != avframe_camera_size_)
   {
-    ROS_ERROR("outbuf size mismatch.  pic_size: %d bufsize: %d\n", pic_size, avframe_camera_size_);
+    ROS_ERROR("outbuf size mismatch.  pic_size: %d bufsize: %d", pic_size, avframe_camera_size_);
     return;
   }
 
@@ -452,7 +452,7 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
   int size = avpicture_layout((AVPicture *)avframe_rgb_, PIX_FMT_RGB24, xsize, ysize, (uint8_t *)RGB, avframe_rgb_size_);
   if (size != avframe_rgb_size_)
   {
-    ROS_ERROR("webcam: avpicture_layout error: %d\n", size);
+    ROS_ERROR("webcam: avpicture_layout error: %d", size);
     return;
   }
 }
@@ -692,7 +692,7 @@ void UsbCam::init_read(unsigned int buffer_size)
 
   if (!buffers_)
   {
-    ROS_ERROR("Out of memory\n");
+    ROS_ERROR("Out of memory");
     exit(EXIT_FAILURE);
   }
 
@@ -701,7 +701,7 @@ void UsbCam::init_read(unsigned int buffer_size)
 
   if (!buffers_[0].start)
   {
-    ROS_ERROR("Out of memory\n");
+    ROS_ERROR("Out of memory");
     exit(EXIT_FAILURE);
   }
 }
@@ -720,7 +720,7 @@ void UsbCam::init_mmap(void)
   {
     if (EINVAL == errno)
     {
-      ROS_ERROR("%s does not support memory mapping\n", camera_dev_);
+      ROS_ERROR_STREAM(camera_dev_ << " does not support memory mapping");
       exit(EXIT_FAILURE);
     }
     else
@@ -731,7 +731,7 @@ void UsbCam::init_mmap(void)
 
   if (req.count < 2)
   {
-    ROS_ERROR("Insufficient buffer memory on %s\n", camera_dev_);
+    ROS_ERROR_STREAM("Insufficient buffer memory on " << camera_dev_);
     exit(EXIT_FAILURE);
   }
 
@@ -739,7 +739,7 @@ void UsbCam::init_mmap(void)
 
   if (!buffers_)
   {
-    ROS_ERROR("Out of memory\n");
+    ROS_ERROR("Out of memory");
     exit(EXIT_FAILURE);
   }
 
@@ -784,9 +784,8 @@ void UsbCam::init_userp(unsigned int buffer_size)
   {
     if (EINVAL == errno)
     {
-      ROS_ERROR("%s does not support "
-                "user pointer i/o\n",
-                camera_dev_);
+      ROS_ERROR_STREAM(camera_dev_ << " does not support "
+                "user pointer i/o");
       exit(EXIT_FAILURE);
     }
     else
@@ -799,7 +798,7 @@ void UsbCam::init_userp(unsigned int buffer_size)
 
   if (!buffers_)
   {
-    ROS_ERROR("Out of memory\n");
+    ROS_ERROR("Out of memory");
     exit(EXIT_FAILURE);
   }
 
@@ -810,7 +809,7 @@ void UsbCam::init_userp(unsigned int buffer_size)
 
     if (!buffers_[n_buffers_].start)
     {
-      ROS_ERROR("Out of memory\n");
+      ROS_ERROR("Out of memory");
       exit(EXIT_FAILURE);
     }
   }
@@ -828,7 +827,7 @@ void UsbCam::init_device(int image_width, int image_height, int framerate)
   {
     if (EINVAL == errno)
     {
-      ROS_ERROR("%s is no V4L2 device\n", camera_dev_);
+      ROS_ERROR_STREAM(camera_dev_ << " is no V4L2 device");
       exit(EXIT_FAILURE);
     }
     else
@@ -839,7 +838,7 @@ void UsbCam::init_device(int image_width, int image_height, int framerate)
 
   if (!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE))
   {
-    ROS_ERROR("%s is no video capture device\n", camera_dev_);
+    ROS_ERROR_STREAM(camera_dev_ << " is no video capture device");
     exit(EXIT_FAILURE);
   }
 
@@ -848,7 +847,7 @@ void UsbCam::init_device(int image_width, int image_height, int framerate)
     case IO_METHOD_READ:
       if (!(cap.capabilities & V4L2_CAP_READWRITE))
       {
-        ROS_ERROR("%s does not support read i/o\n", camera_dev_);
+        ROS_ERROR_STREAM(camera_dev_ << " does not support read i/o");
         exit(EXIT_FAILURE);
       }
 
@@ -858,7 +857,7 @@ void UsbCam::init_device(int image_width, int image_height, int framerate)
     case IO_METHOD_USERPTR:
       if (!(cap.capabilities & V4L2_CAP_STREAMING))
       {
-        ROS_ERROR("%s does not support streaming i/o\n", camera_dev_);
+        ROS_ERROR_STREAM(camera_dev_ << " does not support streaming i/o");
         exit(EXIT_FAILURE);
       }
 
@@ -928,14 +927,14 @@ void UsbCam::init_device(int image_width, int image_height, int framerate)
   memset(&stream_params, 0, sizeof(stream_params));
   stream_params.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
   if (xioctl(fd_, VIDIOC_G_PARM, &stream_params) < 0)
-    errno_exit("Couldn't query v4l fps!\n");
+    errno_exit("Couldn't query v4l fps!");
 
   ROS_DEBUG("Capability flag: 0x%x", stream_params.parm.capture.capability);
 
   stream_params.parm.capture.timeperframe.numerator = 1;
   stream_params.parm.capture.timeperframe.denominator = framerate;
   if (xioctl(fd_, VIDIOC_S_PARM, &stream_params) < 0)
-    ROS_WARN("Couldn't set camera framerate\n");
+    ROS_WARN("Couldn't set camera framerate");
   else
     ROS_DEBUG("Set framerate to be %i", framerate);
 
@@ -967,33 +966,32 @@ void UsbCam::open_device(void)
 {
   struct stat st;
 
-  if (-1 == stat(camera_dev_, &st))
+  if (-1 == stat(camera_dev_.c_str(), &st))
   {
-    ROS_ERROR("Cannot identify '%s': %d, %s\n", camera_dev_, errno, strerror(errno));
+    ROS_ERROR_STREAM("Cannot identify '" << camera_dev_ << "': " << errno << ", " << strerror(errno));
     exit(EXIT_FAILURE);
   }
 
   if (!S_ISCHR(st.st_mode))
   {
-    ROS_ERROR("%s is no device\n", camera_dev_);
+    ROS_ERROR_STREAM(camera_dev_ << " is no device");
     exit(EXIT_FAILURE);
   }
 
-  fd_ = open(camera_dev_, O_RDWR /* required */| O_NONBLOCK, 0);
+  fd_ = open(camera_dev_.c_str(), O_RDWR /* required */| O_NONBLOCK, 0);
 
   if (-1 == fd_)
   {
-    ROS_ERROR("Cannot open '%s': %d, %s\n", camera_dev_, errno, strerror(errno));
+    ROS_ERROR_STREAM("Cannot open '" << camera_dev_ << "': " << errno << ", " << strerror(errno));
     exit(EXIT_FAILURE);
   }
 }
 
-void UsbCam::start(const char* dev, io_method io_method,
+void UsbCam::start(const std::string& dev, io_method io_method,
 		   pixel_format pixel_format, int image_width, int image_height,
 		   int framerate)
 {
-  camera_dev_ = (char*)calloc(1, strlen(dev) + 1);
-  strcpy(camera_dev_, dev);
+  camera_dev_ = dev;
 
   io_ = io_method;
   monochrome_ = false;
@@ -1097,7 +1095,7 @@ void UsbCam::grab_image()
 
   if (0 == r)
   {
-    ROS_ERROR("select timeout\n");
+    ROS_ERROR("select timeout");
     exit(EXIT_FAILURE);
   }
 
@@ -1123,13 +1121,13 @@ void UsbCam::set_auto_focus(int value)
     }
     else
     {
-      ROS_INFO("V4L2_CID_FOCUS_AUTO is not supported\n");
+      ROS_INFO("V4L2_CID_FOCUS_AUTO is not supported");
       return;
     }
   }
   else if (queryctrl.flags & V4L2_CTRL_FLAG_DISABLED)
   {
-    ROS_INFO("V4L2_CID_FOCUS_AUTO is not supported\n");
+    ROS_INFO("V4L2_CID_FOCUS_AUTO is not supported");
     return;
   }
   else

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -56,6 +56,8 @@
 
 #define CLEAR(x) memset (&(x), 0, sizeof (x))
 
+namespace usb_cam {
+
 static void errno_exit(const char * s)
 {
   ROS_ERROR("%s error %d, %s\n", s, errno, strerror(errno));
@@ -1212,4 +1214,6 @@ UsbCam::pixel_format UsbCam::pixel_format_from_string(const std::string& str)
       return PIXEL_FORMAT_RGB24;
     else
       return PIXEL_FORMAT_UNKNOWN;
+}
+
 }

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -1128,3 +1128,34 @@ void UsbCam::camera_set_auto_focus(int value)
   }
 }
 
+/**
+* Set video device parameters via calls to v4l-utils.
+*
+* @param dev The device (e.g., "/dev/video0")
+* @param param The full parameter to set (e.g., "focus_auto=1")
+*/
+void UsbCam::set_v4l_parameters(std::string dev, std::string param)
+{
+  // build the command
+  std::stringstream ss;
+  ss << "v4l2-ctl --device=" << dev << " -c " << param << " 2>&1";
+  std::string cmd = ss.str();
+
+  // capture the output
+  std::string output;
+  int buffer_size = 256;
+  char buffer[buffer_size];
+  FILE *stream = popen(cmd.c_str(), "r");
+  if (stream)
+  {
+    while (!feof(stream))
+      if (fgets(buffer, buffer_size, stream) != NULL)
+        output.append(buffer);
+    pclose(stream);
+    // any output should be an error
+    if (output.length() > 0)
+      ROS_WARN("%s", output.c_str());
+  }
+  else
+    ROS_WARN("usb_cam_node could not run '%s'", cmd.c_str());
+}

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -361,7 +361,7 @@ UsbCam::UsbCam()
 }
 UsbCam::~UsbCam()
 {
-  camera_shutdown();
+  shutdown();
 }
 
 int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
@@ -987,7 +987,7 @@ void UsbCam::open_device(void)
   }
 }
 
-void UsbCam::camera_start(const char* dev, io_method io_method,
+void UsbCam::start(const char* dev, io_method io_method,
 			  pixel_format pixel_format, int image_width, int image_height,
 			  int framerate)
 {
@@ -1037,7 +1037,7 @@ void UsbCam::camera_start(const char* dev, io_method io_method,
   memset(image->image, 0, image->image_size * sizeof(char));
 }
 
-void UsbCam::camera_shutdown(void)
+void UsbCam::shutdown(void)
 {
   stop_capturing();
   uninit_device();
@@ -1060,10 +1060,10 @@ void UsbCam::camera_shutdown(void)
   image = NULL;
 }
 
-void UsbCam::camera_grab_image(sensor_msgs::Image* msg)
+void UsbCam::grab_image(sensor_msgs::Image* msg)
 {
   // grab the image
-  camera_grab_image();
+  grab_image();
   // fill the info
   fillImage(*msg, "rgb8", image->height, image->width, 3 * image->width,
 	    image->image);
@@ -1071,7 +1071,7 @@ void UsbCam::camera_grab_image(sensor_msgs::Image* msg)
   msg->header.stamp = ros::Time::now();
 }
 
-void UsbCam::camera_grab_image()
+void UsbCam::grab_image()
 {
   fd_set fds;
   struct timeval tv;
@@ -1105,7 +1105,7 @@ void UsbCam::camera_grab_image()
 }
 
 // enables/disables auto focus
-void UsbCam::camera_set_auto_focus(int value)
+void UsbCam::set_auto_focus(int value)
 {
   struct v4l2_queryctrl queryctrl;
   struct v4l2_ext_control control;

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -1131,14 +1131,13 @@ void UsbCam::camera_set_auto_focus(int value)
 /**
 * Set video device parameters via calls to v4l-utils.
 *
-* @param dev The device (e.g., "/dev/video0")
 * @param param The full parameter to set (e.g., "focus_auto=1")
 */
-void UsbCam::set_v4l_parameters(std::string dev, std::string param)
+void UsbCam::set_v4l_parameters(std::string param)
 {
   // build the command
   std::stringstream ss;
-  ss << "v4l2-ctl --device=" << dev << " -c " << param << " 2>&1";
+  ss << "v4l2-ctl --device=" << camera_dev << " -c " << param << " 2>&1";
   std::string cmd = ss.str();
 
   // capture the output

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -359,6 +359,10 @@ UsbCam::UsbCam()
     avframe_rgb(NULL), avcodec(NULL), avoptions(NULL), avcodec_context(NULL),
     avframe_camera_size(0), avframe_rgb_size(0), video_sws(NULL), image(NULL) {
 }
+UsbCam::~UsbCam()
+{
+  camera_shutdown();
+}
 
 int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
 {
@@ -1181,4 +1185,32 @@ void UsbCam::set_v4l_parameter(const std::string& param, const std::string& valu
   }
   else
     ROS_WARN("usb_cam_node could not run '%s'", cmd.c_str());
+}
+
+UsbCam::io_method UsbCam::io_method_from_string(const std::string& str)
+{
+  if (str == "mmap")
+    return IO_METHOD_MMAP;
+  else if (str == "read")
+    return IO_METHOD_READ;
+  else if (str == "userptr")
+    return IO_METHOD_USERPTR;
+  else
+    return IO_METHOD_UNKNOWN;
+}
+
+UsbCam::pixel_format UsbCam::pixel_format_from_string(const std::string& str)
+{
+    if (str == "yuyv")
+      return PIXEL_FORMAT_YUYV;
+    else if (str == "uyvy")
+      return PIXEL_FORMAT_UYVY;
+    else if (str == "mjpeg")
+      return PIXEL_FORMAT_MJPEG;
+    else if (str == "yuvmono10")
+      return PIXEL_FORMAT_YUVMONO10;
+    else if (str == "rgb24")
+      return PIXEL_FORMAT_RGB24;
+    else
+      return PIXEL_FORMAT_UNKNOWN;
 }


### PR DESCRIPTION
function and structions in usb_cam.h became public and everything else is private
Also moved some useful functions from UsbCamNode to UsbCam
Fixes #29 