### PR TITLE
fixed check whether calibration file exists

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -97,7 +97,7 @@ public:
     node_.param("camera_info_url", camera_info_url_, std::string(""));
     cinfo_.reset(new camera_info_manager::CameraInfoManager(node_, camera_name_, camera_info_url_));
     // check for default camera info
-    if (camera_info_url_.size() == 0)
+    if (!cinfo_->isCalibrated())
     {
       cinfo_->setCameraName(video_device_name_);
       sensor_msgs::CameraInfo camera_info;


### PR DESCRIPTION
The node does not load the yaml file in case the camera was calibrated. Other camera drivers, such as openni_camera, check with a different condition:
https://github.com/ros-drivers/openni_camera/blob/indigo-devel/src/nodelets/driver.cpp#L167
