### PR TITLE
add start/stop capture services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(usb_cam)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS image_transport roscpp std_msgs sensor_msgs camera_info_manager)
+find_package(catkin REQUIRED COMPONENTS image_transport roscpp std_msgs std_srvs sensor_msgs camera_info_manager)
 
 ## pkg-config libraries
 find_package(PkgConfig REQUIRED)

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -93,6 +93,10 @@ class UsbCam {
   static io_method io_method_from_string(const std::string& str);
   static pixel_format pixel_format_from_string(const std::string& str);
 
+  void stop_capturing(void);
+  void start_capturing(void);
+  bool is_capturing();
+
  private:
   typedef struct
   {
@@ -115,8 +119,6 @@ class UsbCam {
   void mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels);
   void process_image(const void * src, int len, camera_image_t *dest);
   int read_frame();
-  void stop_capturing(void);
-  void start_capturing(void);
   void uninit_device(void);
   void init_read(unsigned int buffer_size);
   void init_mmap(void);
@@ -125,6 +127,7 @@ class UsbCam {
   void close_device(void);
   void open_device(void);
   void grab_image();
+  bool is_capturing_;
 
 
   std::string camera_dev_;

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -39,6 +39,7 @@
 #include <image_transport/image_transport.h>
 #include <camera_info_manager/camera_info_manager.h>
 #include <sstream>
+#include <std_srvs/Empty.h>
 
 namespace usb_cam {
 
@@ -54,12 +55,31 @@ public:
 
   // parameters
   std::string video_device_name_, io_method_name_, pixel_format_name_, camera_name_, camera_info_url_;
+  //std::string start_service_name_, start_service_name_;
+  bool streaming_status_;
   int image_width_, image_height_, framerate_, exposure_, brightness_, contrast_, saturation_, sharpness_, focus_,
       white_balance_, gain_;
   bool autofocus_, autoexposure_, auto_white_balance_;
   boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_;
 
   UsbCam cam_;
+
+  ros::ServiceServer service_start_, service_stop_;
+
+
+
+  bool service_start_cap(std_srvs::Empty::Request  &req, std_srvs::Empty::Response &res )
+  {
+    cam_.start_capturing();
+    return true;
+  }
+
+
+  bool service_stop_cap( std_srvs::Empty::Request  &req, std_srvs::Empty::Response &res )
+  {
+    cam_.stop_capturing();
+    return true;
+  }
 
   UsbCamNode() :
       node_("~")
@@ -97,6 +117,11 @@ public:
     node_.param("camera_name", camera_name_, std::string("head_camera"));
     node_.param("camera_info_url", camera_info_url_, std::string(""));
     cinfo_.reset(new camera_info_manager::CameraInfoManager(node_, camera_name_, camera_info_url_));
+
+    // create Services
+    service_start_ = node_.advertiseService("start_capture", &UsbCamNode::service_start_cap, this);
+    service_stop_ = node_.advertiseService("stop_capture", &UsbCamNode::service_stop_cap, this);
+
     // check for default camera info
     if (!cinfo_->isCalibrated())
     {
@@ -222,13 +247,21 @@ public:
     ros::Rate loop_rate(this->framerate_);
     while (node_.ok())
     {
-      if (!take_and_send_image())
-        ROS_WARN("USB camera did not respond in time.");
+      if (cam_.is_capturing()) {
+        if (!take_and_send_image()) ROS_WARN("USB camera did not respond in time.");
+      }
       ros::spinOnce();
       loop_rate.sleep();
+
     }
     return true;
   }
+
+
+
+
+
+
 };
 
 }

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <build_depend>image_transport</build_depend> 
   <build_depend>roscpp</build_depend> 
   <build_depend>std_msgs</build_depend> 
+  <build_depend>std_srvs</build_depend> 
   <build_depend>sensor_msgs</build_depend> 
   <build_depend>ffmpeg</build_depend>
   <build_depend>camera_info_manager</build_depend>
@@ -24,6 +25,7 @@
   <run_depend>image_transport</run_depend> 
   <run_depend>roscpp</run_depend> 
   <run_depend>std_msgs</run_depend> 
+  <run_depend>std_srvs</run_depend> 
   <run_depend>sensor_msgs</run_depend> 
   <run_depend>ffmpeg</run_depend>
   <run_depend>camera_info_manager</run_depend>

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -356,7 +356,7 @@ void rgb242rgb(char *YUV, char *RGB, int NumPixels)
 UsbCam::UsbCam()
   : io_(IO_METHOD_MMAP), fd_(-1), buffers_(NULL), n_buffers_(0), avframe_camera_(NULL),
     avframe_rgb_(NULL), avcodec_(NULL), avoptions_(NULL), avcodec_context_(NULL),
-    avframe_camera_size_(0), avframe_rgb_size_(0), video_sws_(NULL), image_(NULL) {
+    avframe_camera_size_(0), avframe_rgb_size_(0), video_sws_(NULL), image_(NULL), is_capturing_(false) {
 }
 UsbCam::~UsbCam()
 {
@@ -584,6 +584,8 @@ bool UsbCam::is_capturing() {
 
 void UsbCam::stop_capturing(void)
 {
+  if(!is_capturing_) return;
+
   is_capturing_ = false;
   enum v4l2_buf_type type;
 
@@ -606,6 +608,9 @@ void UsbCam::stop_capturing(void)
 
 void UsbCam::start_capturing(void)
 {
+
+  if(is_capturing_) return;
+
   unsigned int i;
   enum v4l2_buf_type type;
 

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -578,8 +578,13 @@ int UsbCam::read_frame()
   return 1;
 }
 
+bool UsbCam::is_capturing() {
+  return is_capturing_;
+}
+
 void UsbCam::stop_capturing(void)
 {
+  is_capturing_ = false;
   enum v4l2_buf_type type;
 
   switch (io_)
@@ -656,6 +661,7 @@ void UsbCam::start_capturing(void)
 
       break;
   }
+  is_capturing_ = true;
 }
 
 void UsbCam::uninit_device(void)


### PR DESCRIPTION
Add two service to easily start and stop the image streaming when neended.

At startup, the camera stream is open!