### PR TITLE
support for Kinetic / Ubuntu 16.04

### DIFF
--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -375,8 +375,13 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
   }
 
   avcodec_context_ = avcodec_alloc_context3(avcodec_);
+#if LIBAVCODEC_VERSION_MAJOR < 55
   avframe_camera_ = avcodec_alloc_frame();
   avframe_rgb_ = avcodec_alloc_frame();
+#else
+  avframe_camera_ = av_frame_alloc();
+  avframe_rgb_ = av_frame_alloc();
+#endif
 
   avpicture_alloc((AVPicture *)avframe_rgb_, PIX_FMT_RGB24, image_width, image_height);
 


### PR DESCRIPTION
replace use of deprecated functions in newer ffmpeg/libav versions

ffmpeg/libav 55.x (used in ROS Kinetic) deprecated the avcodec_alloc_frame.
